### PR TITLE
Filtered results for AHCB counties

### DIFF
--- a/ahcb.go
+++ b/ahcb.go
@@ -117,9 +117,9 @@ func (s *Server) AHCBCountiesHandler() http.HandlerFunc {
 	}
 }
 
-// AHCBCountiesHandler returns a GeoJSON FeatureCollection containing counties
-// from AHCB. The handler will get the county boundaries for a particular date
-// and by county ID (or IDs if given a comma-separated string of values).
+// AHCBCountiesByIdHandler returns a GeoJSON FeatureCollection containing counties
+// from AHCB. The handler will get the county boundaries for a particular date and
+// by county ID (or IDs if given a comma-separated string of values).
 func (s *Server) AHCBCountiesByIdHandler() http.HandlerFunc {
 	minDate, _ := time.Parse("2006-01-02", "1629-03-04")
 	maxDate, _ := time.Parse("2006-01-02", "2000-12-31")
@@ -168,10 +168,60 @@ func (s *Server) AHCBCountiesByIdHandler() http.HandlerFunc {
 	}
 }
 
-// AHCBCountiesHandler returns a GeoJSON FeatureCollection containing counties
-// from AHCB. The handler will get the county boundaries for a particular date
-// and by state code (or state codes if given a comma-separated string of
-// values).
+// AHCBCountiesByStateTerrIdHandler returns a GeoJSON FeatureCollection containing
+// counties from AHCB. The handler will get the county boundaries for a particular
+// date and by state/territory ID (or IDs if given a comma-separated string of values).
+func (s *Server) AHCBCountiesByStateTerrIdHandler() http.HandlerFunc {
+	minDate, _ := time.Parse("2006-01-02", "1629-03-04")
+	maxDate, _ := time.Parse("2006-01-02", "2000-12-31")
+	query := `
+		SELECT json_build_object(
+			'type','FeatureCollection',
+			'features', json_agg(us_counties.feature)
+		) FROM (
+			SELECT json_build_object(
+				'type', 'Feature',
+				'id', id,
+				'geometry', ST_AsGeoJSON(geom_01)::json,
+				'properties', json_build_object(
+					'name', name,
+					'state_terr', state_terr,
+					'area_sqmi', area_sqmi
+				)
+			) AS feature
+			FROM ahcb_counties
+			WHERE start_date <= $1 AND end_date >= $1
+			AND state_terr_id = ANY($2)
+		) AS us_counties;
+		`
+	stmt, err := s.Database.Prepare(query)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	s.Statements["ahcb-counties-by-id"] = stmt
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		date, err := dateInRange(params["date"], minDate, maxDate)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		var result string
+		stateTerrIds := pq.Array(strings.Split(params["state-terr-id"], ","))
+		err = stmt.QueryRow(date, stateTerrIds).Scan(&result)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, result)
+	}
+}
+
+// AHCBCountiesByStateCodeHandler returns a GeoJSON FeatureCollection containing
+// counties from AHCB. The handler will get the county boundaries for a particular
+// date and by state code (or state codes if given a comma-separated string of values).
 func (s *Server) AHCBCountiesByStateCodeHandler() http.HandlerFunc {
 	minDate, _ := time.Parse("2006-01-02", "1629-03-04")
 	maxDate, _ := time.Parse("2006-01-02", "2000-12-31")
@@ -209,8 +259,8 @@ func (s *Server) AHCBCountiesByStateCodeHandler() http.HandlerFunc {
 			return
 		}
 		var result string
-		ids := pq.Array(strings.Split(params["state-code"], ","))
-		err = stmt.QueryRow(date, ids).Scan(&result)
+		stateCodes := pq.Array(strings.Split(params["state-code"], ","))
+		err = stmt.QueryRow(date, stateCodes).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/ahcb.go
+++ b/ahcb.go
@@ -69,24 +69,16 @@ func (s *Server) AHCBStatesHandler() http.HandlerFunc {
 	}
 }
 
-// AHCBCountiesHandler returns a GeoJSON FeatureCollection containing countries
+// AHCBCountiesHandler returns a GeoJSON FeatureCollection containing counties
 // from AHCB. The handler will get the county boundaries for a particular date.
-// Optionally, a comma-separated array of values for either county IDs or the
-// state/territory names can be used to filter the results.
 func (s *Server) AHCBCountiesHandler() http.HandlerFunc {
-
-	// The minimum and maximum dates are the range of dates for states in AHCB.
 	minDate, _ := time.Parse("2006-01-02", "1629-03-04")
 	maxDate, _ := time.Parse("2006-01-02", "2000-12-31")
-
-	// Build the GeoJSON in the query itself. This query will be sent to the
-	// database as a prepared statement.
 	query := `
 		SELECT json_build_object(
 			'type','FeatureCollection',
 			'features', json_agg(us_counties.feature)
-		)
-		FROM (
+		) FROM (
 			SELECT json_build_object(
 				'type', 'Feature',
 				'id', id,
@@ -94,72 +86,19 @@ func (s *Server) AHCBCountiesHandler() http.HandlerFunc {
 				'properties', json_build_object(
 					'name', name,
 					'state_terr', state_terr,
-					'area_sqmi', area_sqmi)
+					'area_sqmi', area_sqmi
+				)
 			) AS feature
 			FROM ahcb_counties
 			WHERE start_date <= $1 AND end_date >= $1
-			) AS us_counties;
+		) AS us_counties;
 		`
 	stmt, err := s.Database.Prepare(query)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	s.Statements["ahcb-counties"] = stmt // Will be closed at shutdown
-
-	queryStateterrFilter := `
-		SELECT json_build_object(
-			'type','FeatureCollection',
-			'features', json_agg(us_counties.feature)
-		)
-		FROM (
-			SELECT json_build_object(
-				'type', 'Feature',
-				'id', id,
-				'geometry', ST_AsGeoJSON(geom_01)::json,
-				'properties', json_build_object(
-					'name', name,
-					'state_terr', state_terr,
-					'area_sqmi', area_sqmi)
-			) AS feature
-			FROM ahcb_counties
-			WHERE start_date <= $1 AND end_date >= $1
-			AND state_terr = ANY($2)
-			) AS us_counties;
-		`
-	stmtStateterrFilter, err := s.Database.Prepare(queryStateterrFilter)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	s.Statements["ahcb-counties-stateterr-filter"] = stmtStateterrFilter // Will be closed at shutdown
-
-	queryCountyFilter := `
-		SELECT json_build_object(
-			'type','FeatureCollection',
-			'features', json_agg(us_counties.feature)
-		)
-		FROM (
-			SELECT json_build_object(
-				'type', 'Feature',
-				'id', id,
-				'geometry', ST_AsGeoJSON(geom_01)::json,
-				'properties', json_build_object(
-					'name', name,
-					'state_terr', state_terr,
-					'area_sqmi', area_sqmi)
-			) AS feature
-			FROM ahcb_counties
-			WHERE start_date <= $1 AND end_date >= $1
-			AND id = ANY($2)
-			) AS us_counties;
-		`
-	stmtCountyFilter, err := s.Database.Prepare(queryCountyFilter)
-	if err != nil {
-		log.Fatalln(err)
-	}
-	s.Statements["ahcb-counties-county-filter"] = stmtCountyFilter // Will be closed at shutdown
-
+	s.Statements["ahcb-counties"] = stmt
 	return func(w http.ResponseWriter, r *http.Request) {
-
 		params := mux.Vars(r)
 		date, err := dateInRange(params["date"], minDate, maxDate)
 		if err != nil {
@@ -167,26 +106,116 @@ func (s *Server) AHCBCountiesHandler() http.HandlerFunc {
 			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 			return
 		}
-
-		var result string // result will be a string containing GeoJSON
-		stateterrValue := r.FormValue("state_terr")
-		idValue := r.FormValue("id")
-		if "" != stateterrValue {
-			stateterrs := pq.Array(strings.Split(stateterrValue, ","))
-			err = stmtStateterrFilter.QueryRow(date, stateterrs).Scan(&result)
-		} else if "" != idValue {
-			ids := pq.Array(strings.Split(idValue, ","))
-			err = stmtCountyFilter.QueryRow(date, ids).Scan(&result)
-		} else {
-			err = stmt.QueryRow(date).Scan(&result)
-		}
+		var result string
+		err = stmt.QueryRow(date).Scan(&result)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
-
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, result)
+	}
+}
 
+// AHCBCountiesHandler returns a GeoJSON FeatureCollection containing counties
+// from AHCB. The handler will get the county boundaries for a particular date
+// and by county ID (or IDs if given a comma-separated string of values).
+func (s *Server) AHCBCountiesByIdHandler() http.HandlerFunc {
+	minDate, _ := time.Parse("2006-01-02", "1629-03-04")
+	maxDate, _ := time.Parse("2006-01-02", "2000-12-31")
+	query := `
+		SELECT json_build_object(
+			'type','FeatureCollection',
+			'features', json_agg(us_counties.feature)
+		) FROM (
+			SELECT json_build_object(
+				'type', 'Feature',
+				'id', id,
+				'geometry', ST_AsGeoJSON(geom_01)::json,
+				'properties', json_build_object(
+					'name', name,
+					'state_terr', state_terr,
+					'area_sqmi', area_sqmi
+				)
+			) AS feature
+			FROM ahcb_counties
+			WHERE start_date <= $1 AND end_date >= $1
+			AND id = ANY($2)
+		) AS us_counties;
+		`
+	stmt, err := s.Database.Prepare(query)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	s.Statements["ahcb-counties-by-id"] = stmt
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		date, err := dateInRange(params["date"], minDate, maxDate)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		var result string
+		ids := pq.Array(strings.Split(params["id"], ","))
+		err = stmt.QueryRow(date, ids).Scan(&result)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, result)
+	}
+}
+
+// AHCBCountiesHandler returns a GeoJSON FeatureCollection containing counties
+// from AHCB. The handler will get the county boundaries for a particular date
+// and by state code (or state codes if given a comma-separated string of
+// values).
+func (s *Server) AHCBCountiesByStateCodeHandler() http.HandlerFunc {
+	minDate, _ := time.Parse("2006-01-02", "1629-03-04")
+	maxDate, _ := time.Parse("2006-01-02", "2000-12-31")
+	query := `
+		SELECT json_build_object(
+			'type','FeatureCollection',
+			'features', json_agg(us_counties.feature)
+		) FROM (
+			SELECT json_build_object(
+				'type', 'Feature',
+				'id', id,
+				'geometry', ST_AsGeoJSON(geom_01)::json,
+				'properties', json_build_object(
+					'name', name,
+					'state_terr', state_terr,
+					'area_sqmi', area_sqmi
+				)
+			) AS feature
+			FROM ahcb_counties
+			WHERE start_date <= $1 AND end_date >= $1
+			AND state_code = ANY($2)
+		) AS us_counties;
+		`
+	stmt, err := s.Database.Prepare(query)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	s.Statements["ahcb-counties-by-state-code"] = stmt
+	return func(w http.ResponseWriter, r *http.Request) {
+		params := mux.Vars(r)
+		date, err := dateInRange(params["date"], minDate, maxDate)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
+		var result string
+		ids := pq.Array(strings.Split(params["state-code"], ","))
+		err = stmt.QueryRow(date, ids).Scan(&result)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, result)
 	}
 }

--- a/ahcb.go
+++ b/ahcb.go
@@ -71,6 +71,8 @@ func (s *Server) AHCBStatesHandler() http.HandlerFunc {
 
 // AHCBCountiesHandler returns a GeoJSON FeatureCollection containing countries
 // from AHCB. The handler will get the county boundaries for a particular date.
+// Optionally, a comma-separated array of values for either county IDs or the
+// state/territory names can be used to filter the results.
 func (s *Server) AHCBCountiesHandler() http.HandlerFunc {
 
 	// The minimum and maximum dates are the range of dates for states in AHCB.

--- a/ahcb.go
+++ b/ahcb.go
@@ -86,6 +86,8 @@ func (s *Server) AHCBCountiesHandler() http.HandlerFunc {
 				'properties', json_build_object(
 					'name', name,
 					'state_terr', state_terr,
+					'state_terr_id', state_terr_id,
+					'state_code', state_code,
 					'area_sqmi', area_sqmi
 				)
 			) AS feature
@@ -135,6 +137,8 @@ func (s *Server) AHCBCountiesByIdHandler() http.HandlerFunc {
 				'properties', json_build_object(
 					'name', name,
 					'state_terr', state_terr,
+					'state_terr_id', state_terr_id,
+					'state_code', state_code,
 					'area_sqmi', area_sqmi
 				)
 			) AS feature
@@ -186,6 +190,8 @@ func (s *Server) AHCBCountiesByStateTerrIdHandler() http.HandlerFunc {
 				'properties', json_build_object(
 					'name', name,
 					'state_terr', state_terr,
+					'state_terr_id', state_terr_id,
+					'state_code', state_code,
 					'area_sqmi', area_sqmi
 				)
 			) AS feature
@@ -237,6 +243,8 @@ func (s *Server) AHCBCountiesByStateCodeHandler() http.HandlerFunc {
 				'properties', json_build_object(
 					'name', name,
 					'state_terr', state_terr,
+					'state_terr_id', state_terr_id,
+					'state_code', state_code,
 					'area_sqmi', area_sqmi
 				)
 			) AS feature

--- a/cmd/relecapi/main_test.go
+++ b/cmd/relecapi/main_test.go
@@ -142,9 +142,9 @@ func TestAHCBCounties(t *testing.T) {
 	}
 }
 
-func TestAHCBCountiesIdFilter(t *testing.T) {
+func TestAHCBCountiesByID(t *testing.T) {
 	req, _ := http.NewRequest("GET",
-		"/ahcb/counties/1980-12-31/?id=vas_fairfax,vas_arlington,vas_princewilliam", nil)
+		"/ahcb/counties/1980-12-31/id/vas_fairfax,vas_arlington,vas_princewilliam/", nil)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 
@@ -164,9 +164,9 @@ func TestAHCBCountiesIdFilter(t *testing.T) {
 	}
 }
 
-func TestAHCBCountiesStateterrFilter(t *testing.T) {
+func TestAHCBCountiesByStateCode(t *testing.T) {
 	req, _ := http.NewRequest("GET",
-		"/ahcb/counties/1940-12-31/?state_terr=North+Dakota,South+Dakota", nil)
+		"/ahcb/counties/1940-12-31/state-code/nd,sd/", nil)
 	response := executeRequest(req)
 	checkResponseCode(t, http.StatusOK, response.Code)
 

--- a/cmd/relecapi/main_test.go
+++ b/cmd/relecapi/main_test.go
@@ -140,7 +140,50 @@ func TestAHCBCounties(t *testing.T) {
 	if len(data.Features) != 3113 {
 		t.Error("Incorrect number of features returned.")
 	}
+}
 
+func TestAHCBCountiesIdFilter(t *testing.T) {
+	req, _ := http.NewRequest("GET",
+		"/ahcb/counties/1980-12-31/?id=vas_fairfax,vas_arlington,vas_princewilliam", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	// Get the data
+	var data GeoJSONFeatureCollection
+	err := json.Unmarshal(response.Body.Bytes(), &data)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if data.Type != "FeatureCollection" {
+		t.Error("Data is not a FeatureCollection.")
+	}
+
+	if len(data.Features) != 3 {
+		t.Error("Incorrect number of features returned.")
+	}
+}
+
+func TestAHCBCountiesStateterrFilter(t *testing.T) {
+	req, _ := http.NewRequest("GET",
+		"/ahcb/counties/1940-12-31/?state_terr=North+Dakota,South+Dakota", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	// Get the data
+	var data GeoJSONFeatureCollection
+	err := json.Unmarshal(response.Body.Bytes(), &data)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if data.Type != "FeatureCollection" {
+		t.Error("Data is not a FeatureCollection.")
+	}
+
+	if len(data.Features) != 122 {
+		t.Error("Incorrect number of features returned.")
+	}
 }
 
 func TestNorthAmerica(t *testing.T) {
@@ -162,8 +205,8 @@ func TestNorthAmerica(t *testing.T) {
 	if len(data.Features) != 17 {
 		t.Error("Incorrect number of features returned.")
 	}
-
 }
+
 func Test404(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/nodatahere/", nil)
 	response := executeRequest(req)

--- a/cmd/relecapi/main_test.go
+++ b/cmd/relecapi/main_test.go
@@ -164,6 +164,28 @@ func TestAHCBCountiesByID(t *testing.T) {
 	}
 }
 
+func TestAHCBCountiesByStateTerrId(t *testing.T) {
+	req, _ := http.NewRequest("GET",
+		"/ahcb/counties/1980-12-31/state-terr-id/ga_state,va_state/", nil)
+	response := executeRequest(req)
+	checkResponseCode(t, http.StatusOK, response.Code)
+
+	// Get the data
+	var data GeoJSONFeatureCollection
+	err := json.Unmarshal(response.Body.Bytes(), &data)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if data.Type != "FeatureCollection" {
+		t.Error("Data is not a FeatureCollection.")
+	}
+
+	if len(data.Features) != 295 {
+		t.Error("Incorrect number of features returned.")
+	}
+}
+
 func TestAHCBCountiesByStateCode(t *testing.T) {
 	req, _ := http.NewRequest("GET",
 		"/ahcb/counties/1940-12-31/state-code/nd,sd/", nil)

--- a/routes.go
+++ b/routes.go
@@ -6,7 +6,7 @@ func (s *Server) Routes() {
 	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/id/{id:[a-z_,]+}/", s.AHCBCountiesByIdHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/state-terr-id/{state-terr-id:[a-z_,]+}/", s.AHCBCountiesByStateTerrIdHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/state-code/{state-code:[a-z,]+}/", s.AHCBCountiesByStateCodeHandler()).Methods("GET", "HEAD")
-	s.Router.HandleFunc("/ahcb/states/{date}/", s.AHCBStatesHandler()).Methods("GET", "HEAD")
+	s.Router.HandleFunc("/ahcb/states/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/", s.AHCBStatesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/catholic-dioceses/", s.CatholicDiocesesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ne/northamerica/", s.NENorthAmericaHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/presbyterians/", s.PresbyteriansHandler()).Methods("GET", "HEAD")

--- a/routes.go
+++ b/routes.go
@@ -4,6 +4,7 @@ package relecapi
 func (s *Server) Routes() {
 	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/", s.AHCBCountiesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/id/{id:[a-z_,]+}/", s.AHCBCountiesByIdHandler()).Methods("GET", "HEAD")
+	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/state-terr-id/{state-terr-id:[a-z_,]+}/", s.AHCBCountiesByStateTerrIdHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/state-code/{state-code:[a-z,]+}/", s.AHCBCountiesByStateCodeHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ahcb/states/{date}/", s.AHCBStatesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/catholic-dioceses/", s.CatholicDiocesesHandler()).Methods("GET", "HEAD")

--- a/routes.go
+++ b/routes.go
@@ -2,7 +2,9 @@ package relecapi
 
 // Routes registers the handlers for the URLs that should be served.
 func (s *Server) Routes() {
-	s.Router.HandleFunc("/ahcb/counties/{date}/", s.AHCBCountiesHandler()).Methods("GET", "HEAD")
+	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/", s.AHCBCountiesHandler()).Methods("GET", "HEAD")
+	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/id/{id:[a-z_,]+}/", s.AHCBCountiesByIdHandler()).Methods("GET", "HEAD")
+	s.Router.HandleFunc("/ahcb/counties/{date:[0-9]{4}-[0-9]{2}-[0-9]{2}}/state-code/{state-code:[a-z,]+}/", s.AHCBCountiesByStateCodeHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ahcb/states/{date}/", s.AHCBStatesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/catholic-dioceses/", s.CatholicDiocesesHandler()).Methods("GET", "HEAD")
 	s.Router.HandleFunc("/ne/northamerica/", s.NENorthAmericaHandler()).Methods("GET", "HEAD")


### PR DESCRIPTION
@jimsafley This looks great. Thanks for adding it. 🚀 

I added tests for the filters. Do they accurately represent your intentions? I also put indexes on the relevant columns in the database.

This is a dataset question, but would a different representation of the data in the `state_terr` column make this endpoint easier to use? For example, the names in that column can have spaces, and they can vary quite a bit for what is conceptually the same thing. E.g., `Alaska`, `Alaska District`, `Alaska Department`, `Alaska Territory`. Would a new column with, e.g., a postal code (`AK`) be easier to work with? That could be added to the database. It completely depends on what data you envision being easily available in the client.